### PR TITLE
fix writing of intermediate gdxes for calibration

### DIFF
--- a/core/loop.gms
+++ b/core/loop.gms
@@ -154,16 +154,18 @@ if (o_modelstat le 2,
   !! retain gdxes of intermediate iterations by copying them using shell
   !! commands
   if (c_keep_iteration_gdxes eq 1,
-    put_utility "shell" / "printf '%03i\n'" iteration.val:0:0
-                          "| sed 's/\(.*\)/fulldata.gdx fulldata_\1.gdx/'"
-                          "| xargs -n 2 cp"
+    put_utility logfile, "shell" / 
+      "printf '%03i\n'" iteration.val:0:0
+      "| sed 's/\(.*\)/fulldata.gdx fulldata_\1.gdx/'"
+      "| xargs -n 2 cp"
   );
 else
   execute_unload 'non_optimal';
   if (c_keep_iteration_gdxes eq 1,
-    put_utility "shell" / "printf '%03i\n'" iteration.val:0:0
-                          "| sed 's/\(.*\)/non_optimal.gdx non_optimal_\1.gdx/'"
-                          "| xargs -n 2 cp"
+    put_utility logfile, "shell" / 
+      "printf '%03i\n'" iteration.val:0:0
+      "| sed 's/\(.*\)/non_optimal.gdx non_optimal_\1.gdx/'"
+      "| xargs -n 2 cp"
   );
 );
 

--- a/main.gms
+++ b/main.gms
@@ -109,6 +109,13 @@ $offdigit
 *** turn profiling off (0) or on (1-3, different levels of detail)
 option profile = 0;
 
+*** enable dumping information to the log
+file logfile /""/;
+
+logfile.lw =  0;
+logfile.nw = 15;
+logfile.nd =  9;
+
 *--------------------------------------------------------------------------
 ***           basic scenario choices
 *--------------------------------------------------------------------------

--- a/modules/29_CES_parameters/calibrate/preloop.gms
+++ b/modules/29_CES_parameters/calibrate/preloop.gms
@@ -13,12 +13,6 @@ display "check sets production function 29", ces_29, in_29, ppf_29, ipf_29,
         ppf_beyondcalib_29, ipf_beyond_29;
 display "check starting pm_cesdata", pm_cesdata;
 
-file logfile /""/;
-
-logfile.lw =  0;
-logfile.nw = 15;
-logfile.nd =  9;
-
 *** Check if new structure flag is not set but should be
 $ifthen.check_structure %c_CES_calibration_new_structure% == "0"
 Execute_Load 'input'  ces2_29=cesOut2cesIn;


### PR DESCRIPTION
- 29_CES_parameters/calibrate left a .pc = 5 configured file open which
  prevents put_utility from invoking features, therefore

- use put_utility with logfile, which we know is not .pc = 5, thus
  clearing the .pc attribute
- move the definition of logfile to main.gms, so it is defined no
  matter which realisation of 29_CES_parameters is used